### PR TITLE
Get configuration from secrets instead of typing in manually

### DIFF
--- a/build/infrastructure/azfun-coordinator.tf
+++ b/build/infrastructure/azfun-coordinator.tf
@@ -33,14 +33,14 @@ module "azfun_coordinator" {
     CONNECTION_STRING_SERVICEBUS                        = data.azurerm_key_vault_secret.POST_OFFICE_QUEUE_CONNECTION_STRING.value
     CONNECTION_STRING_DATABRICKS                        = "https://${azurerm_databricks_workspace.databricksworkspace.workspace_url}"
     TOKEN_DATABRICKS                                    = "!!!!!If this is missing run databricks cluster job"
-    INPUTSTORAGE_CONTAINER_NAME                         =  "${var.INPUTSTORAGE_CONTAINER_NAME}"
-    INPUTSTORAGE_ACCOUNT_NAME                           = "${var.INPUTSTORAGE_ACCOUNT_NAME}"
-    INPUTSTORAGE_ACCOUNT_KEY                            = "${var.INPUTSTORAGE_ACCOUNT_KEY}"
-    INPUT_PATH                                          = "${var.INPUT_PATH}"
+    INPUTSTORAGE_CONTAINER_NAME                         =  "${var.inputstorage_container_name}"
+    INPUTSTORAGE_ACCOUNT_NAME                           = "${var.inputstorage_account_name}"
+    INPUTSTORAGE_ACCOUNT_KEY                            = "${var.inputstorage_account_key}"
+    INPUT_PATH                                          = "${var.input_path}"
     RESULT_URL                                          = "https://${local.azfun_coordinator_name}.azurewebsites.net/api/ResultReceiver"
     PYTHON_FILE                                         = "dbfs:/aggregation/aggregation_trigger.py"
     CLUSTER_TIMEOUT_MINUTES                             = "10"
-    GRID_LOSS_SYS_COR_PATH                              = "${var.GRID_LOSS_SYS_COR_PATH}"
+    GRID_LOSS_SYS_COR_PATH                              = "${var.grid_loss_sys_cor_path}"
     
   }
   dependencies                              = [

--- a/build/infrastructure/azfun-coordinator.tf
+++ b/build/infrastructure/azfun-coordinator.tf
@@ -33,14 +33,14 @@ module "azfun_coordinator" {
     CONNECTION_STRING_SERVICEBUS                        = data.azurerm_key_vault_secret.POST_OFFICE_QUEUE_CONNECTION_STRING.value
     CONNECTION_STRING_DATABRICKS                        = "https://${azurerm_databricks_workspace.databricksworkspace.workspace_url}"
     TOKEN_DATABRICKS                                    = "!!!!!If this is missing run databricks cluster job"
-    INPUTSTORAGE_CONTAINER_NAME                         =  "${var.inputstorage_container_name}"
-    INPUTSTORAGE_ACCOUNT_NAME                           = "${var.inputstorage_account_name}"
-    INPUTSTORAGE_ACCOUNT_KEY                            = "${var.inputstorage_account_key}"
-    INPUT_PATH                                          = "${var.input_path}"
+    INPUTSTORAGE_CONTAINER_NAME                         =  var.inputstorage_container_name
+    INPUTSTORAGE_ACCOUNT_NAME                           =  var.inputstorage_account_name
+    INPUTSTORAGE_ACCOUNT_KEY                            =  var.inputstorage_account_key
+    INPUT_PATH                                          =  var.input_path
     RESULT_URL                                          = "https://${local.azfun_coordinator_name}.azurewebsites.net/api/ResultReceiver"
     PYTHON_FILE                                         = "dbfs:/aggregation/aggregation_trigger.py"
     CLUSTER_TIMEOUT_MINUTES                             = "10"
-    GRID_LOSS_SYS_COR_PATH                              = "${var.grid_loss_sys_cor_path}"
+    GRID_LOSS_SYS_COR_PATH                              = var.grid_loss_sys_cor_path
     
   }
   dependencies                              = [

--- a/build/infrastructure/azfun-coordinator.tf
+++ b/build/infrastructure/azfun-coordinator.tf
@@ -32,15 +32,15 @@ module "azfun_coordinator" {
     FUNCTIONS_WORKER_RUNTIME                            = "dotnet"
     CONNECTION_STRING_SERVICEBUS                        = data.azurerm_key_vault_secret.POST_OFFICE_QUEUE_CONNECTION_STRING.value
     CONNECTION_STRING_DATABRICKS                        = "https://${azurerm_databricks_workspace.databricksworkspace.workspace_url}"
-    TOKEN_DATABRICKS                                    = "XXXXX"
-    INPUTSTORAGE_CONTAINER_NAME                         = "XXXXX"
-    INPUTSTORAGE_ACCOUNT_NAME                           = "XXXXX"
-    INPUTSTORAGE_ACCOUNT_KEY                            = "XXXXX"
-    INPUT_PATH                                          = "XXXXX"
+    TOKEN_DATABRICKS                                    = "!!!!!If this is missing run databricks cluster job"
+    INPUTSTORAGE_CONTAINER_NAME                         =  "${var.INPUTSTORAGE_CONTAINER_NAME}"
+    INPUTSTORAGE_ACCOUNT_NAME                           = "${var.INPUTSTORAGE_ACCOUNT_NAME}"
+    INPUTSTORAGE_ACCOUNT_KEY                            = "${var.INPUTSTORAGE_ACCOUNT_KEY}"
+    INPUT_PATH                                          = "${var.INPUT_PATH}"
     RESULT_URL                                          = "https://${local.azfun_coordinator_name}.azurewebsites.net/api/ResultReceiver"
     PYTHON_FILE                                         = "dbfs:/aggregation/aggregation_trigger.py"
     CLUSTER_TIMEOUT_MINUTES                             = "10"
-    GRID_LOSS_SYS_COR_PATH                              = "XXXXX"
+    GRID_LOSS_SYS_COR_PATH                              = "${var.GRID_LOSS_SYS_COR_PATH}"
     
   }
   dependencies                              = [

--- a/build/infrastructure/variables.tf
+++ b/build/infrastructure/variables.tf
@@ -40,10 +40,6 @@ variable "sharedresources_resource_group_name" {
   description   = "Resource group name of the Core keyvaults location"
 }
 
-variable "sharedresources_resource_group_name" {
-  type          = string
-  description   = "Resource group name of the Core keyvaults location"
-}
 
 variable "inputstorage_container_name" {
   type          = string

--- a/build/infrastructure/variables.tf
+++ b/build/infrastructure/variables.tf
@@ -39,3 +39,33 @@ variable "sharedresources_resource_group_name" {
   type          = string
   description   = "Resource group name of the Core keyvaults location"
 }
+
+variable "sharedresources_resource_group_name" {
+  type          = string
+  description   = "Resource group name of the Core keyvaults location"
+}
+
+variable "inputstorage_container_name" {
+  type          = string
+  description   = "Container name used in aggregation job"
+}
+
+variable "inputstorage_account_name" {
+  type          = string
+  description   = "Storage account name used in aggregation job"
+}
+
+variable "inputstorage_account_key" {
+  type          = string
+  description   = "Storage account key used in aggregation job"
+}
+
+variable "input_path" {
+  type          = string
+  description   = "Input path used in aggregation job"
+}
+
+variable "grid_loss_sys_cor_path" {
+  type          = string
+  description   = "Path to location of system correction and grid loss used in aggregation job"
+}


### PR DESCRIPTION
Before this PR there were values in the coordinator that had to be typed in manually to replace XXXXX values.
These are now pulled from github environment secrets