### PR TITLE
Include build when merged on main to create base report for codecov

### DIFF
--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -13,6 +13,9 @@
  # limitations under the License.
 name: Code coverage
 on:
+   push:
+     branches:
+       - main
    pull_request:
      branches:
        - main
@@ -51,7 +54,7 @@ jobs:
   
   collect_coverage_python:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip_python != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip_python != 'true' || github.ref == 'refs/heads/main' }}
     name: Collect code coverage Python
     runs-on: ubuntu-latest
     steps:
@@ -73,7 +76,7 @@ jobs:
   
   collect_coverage_dotnet:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip_dotnet != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip_dotnet != 'true' || github.ref == 'refs/heads/main' }}
     name: Collect code coverage .NET
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Description

Codecov needs a coverage report created on the default target branch.
In our case this is the main branch.

This PR ensures that the CodeCov-CI is run when a PR is completed or a push to main occurs.
