### PR TITLE
Function keys on internal endopints

### DIFF
--- a/build/infrastructure/azfun-coordinator.tf
+++ b/build/infrastructure/azfun-coordinator.tf
@@ -44,7 +44,7 @@ module "azfun_coordinator" {
     CLUSTER_TIMEOUT_MINUTES                             = "10"
     GRID_LOSS_SYS_COR_PATH                              = var.grid_loss_sys_cor_path
     DATABASE_CONNECTIONSTRING                           = "Server=tcp:${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_URL.value},1433;Initial Catalog=${azurerm_mssql_database.sqldb_metadata.name};Persist Security Info=False;User ID=${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_ADMIN_NAME.value};Password=${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_ADMIN_PASSWORD.value};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
-    
+    HOST_KEY                                            = data.azurerm_function_app_host_keys.default_function_key.value
   }
   
   dependencies                              = [
@@ -52,6 +52,11 @@ module "azfun_coordinator" {
     module.azfun_coordinator_plan.dependent_on,
     module.azfun_coordinator_stor.dependent_on,
   ]
+}
+
+data "azurerm_function_app_host_keys" "host_keys" {
+  name                = local.azfun_coordinator_name
+  resource_group_name = data.azurerm_resource_group.main.name
 }
 
 module "azfun_coordinator_plan" {

--- a/build/infrastructure/azfun-coordinator.tf
+++ b/build/infrastructure/azfun-coordinator.tf
@@ -44,7 +44,7 @@ module "azfun_coordinator" {
     CLUSTER_TIMEOUT_MINUTES                             = "10"
     GRID_LOSS_SYS_COR_PATH                              = var.grid_loss_sys_cor_path
     DATABASE_CONNECTIONSTRING                           = "Server=tcp:${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_URL.value},1433;Initial Catalog=${azurerm_mssql_database.sqldb_metadata.name};Persist Security Info=False;User ID=${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_ADMIN_NAME.value};Password=${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_ADMIN_PASSWORD.value};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
-    HOST_KEY                                            = data.azurerm_function_app_host_keys.host_keys.value
+    HOST_KEY                                            = data.azurerm_function_app_host_keys.host_keys.default_function_key
   }
   
   dependencies                              = [

--- a/build/infrastructure/azfun-coordinator.tf
+++ b/build/infrastructure/azfun-coordinator.tf
@@ -44,7 +44,7 @@ module "azfun_coordinator" {
     CLUSTER_TIMEOUT_MINUTES                             = "10"
     GRID_LOSS_SYS_COR_PATH                              = var.grid_loss_sys_cor_path
     DATABASE_CONNECTIONSTRING                           = "Server=tcp:${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_URL.value},1433;Initial Catalog=${azurerm_mssql_database.sqldb_metadata.name};Persist Security Info=False;User ID=${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_ADMIN_NAME.value};Password=${data.azurerm_key_vault_secret.SHARED_RESOURCES_DB_ADMIN_PASSWORD.value};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
-    HOST_KEY                                            = data.azurerm_function_app_host_keys.default_function_key.value
+    HOST_KEY                                            = data.azurerm_function_app_host_keys.host_keys.value
   }
   
   dependencies                              = [

--- a/source/coordinator/GreenEnergyHub.Aggregation.Application/Coordinator/CoordinatorService.cs
+++ b/source/coordinator/GreenEnergyHub.Aggregation.Application/Coordinator/CoordinatorService.cs
@@ -88,7 +88,7 @@ namespace GreenEnergyHub.Aggregation.Application.Coordinator
                 $"--telemetry-instrumentation-key={_coordinatorSettings.TelemetryInstrumentationKey}",
                 $"--process-type={processType}",
                 $"--result-url={_coordinatorSettings.ResultUrl}?code={_coordinatorSettings.HostKey}",
-                $"--snapshot-url={_coordinatorSettings.SnapshotUrl}",
+                $"--snapshot-url={_coordinatorSettings.SnapshotUrl}?code={_coordinatorSettings.HostKey}",
                 $"--result-id={resultId}",
                 $"--persist-source-dataframe={persist}",
                 $"--persist-source-dataframe-location={_coordinatorSettings.PersistLocation}",

--- a/source/coordinator/GreenEnergyHub.Aggregation.Application/Coordinator/CoordinatorService.cs
+++ b/source/coordinator/GreenEnergyHub.Aggregation.Application/Coordinator/CoordinatorService.cs
@@ -87,7 +87,7 @@ namespace GreenEnergyHub.Aggregation.Application.Coordinator
                 $"--end-date-time={endTime.ToIso8601GeneralString()}",
                 $"--telemetry-instrumentation-key={_coordinatorSettings.TelemetryInstrumentationKey}",
                 $"--process-type={processType}",
-                $"--result-url={_coordinatorSettings.ResultUrl}",
+                $"--result-url={_coordinatorSettings.ResultUrl}?code={_coordinatorSettings.HostKey}",
                 $"--snapshot-url={_coordinatorSettings.SnapshotUrl}",
                 $"--result-id={resultId}",
                 $"--persist-source-dataframe={persist}",

--- a/source/coordinator/GreenEnergyHub.Aggregation.Coordinator/CoordinationTriggers.cs
+++ b/source/coordinator/GreenEnergyHub.Aggregation.Coordinator/CoordinationTriggers.cs
@@ -41,7 +41,7 @@ namespace GreenEnergyHub.Aggregation.CoordinatorFunction
 
         [FunctionName("SnapshotReceiver")]
         public static async Task<OkResult> SnapshotReceiverAsync(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)]
+            [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)]
             HttpRequest req,
             ILogger log)
         {

--- a/source/coordinator/GreenEnergyHub.Aggregation.Coordinator/CoordinationTriggers.cs
+++ b/source/coordinator/GreenEnergyHub.Aggregation.Coordinator/CoordinationTriggers.cs
@@ -108,7 +108,7 @@ namespace GreenEnergyHub.Aggregation.CoordinatorFunction
 
         [FunctionName("ResultReceiver")]
         public async Task<OkResult> ResultReceiverAsync(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)]
+            [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)]
             HttpRequest req,
             ILogger log,
             CancellationToken cancellationToken)

--- a/source/coordinator/GreenEnergyHub.Aggregation.Coordinator/Startup.cs
+++ b/source/coordinator/GreenEnergyHub.Aggregation.Coordinator/Startup.cs
@@ -58,6 +58,7 @@ namespace GreenEnergyHub.Aggregation.CoordinatorFunction
             var resultUrl = new Uri(StartupConfig.GetConfigurationVariable("RESULT_URL"));
             var snapshotUrl = new Uri(StartupConfig.GetConfigurationVariable("SNAPSHOT_URL"));
             var pythonFile = StartupConfig.GetConfigurationVariable("PYTHON_FILE");
+            var hostKey = StartupConfig.GetConfigurationVariable("HOST_KEY");
             if (!int.TryParse(StartupConfig.GetConfigurationVariable("CLUSTER_TIMEOUT_MINUTES"), out var clusterTimeoutMinutes))
             {
                 throw new Exception($"Could not parse cluster timeout minutes in {nameof(Startup)}");
@@ -78,6 +79,7 @@ namespace GreenEnergyHub.Aggregation.CoordinatorFunction
                 SnapshotUrl = snapshotUrl,
                 PythonFile = pythonFile,
                 ClusterTimeoutMinutes = clusterTimeoutMinutes,
+                HostKey = hostKey,
             };
 
             builder.Services.AddSingleton(coordinatorSettings);

--- a/source/coordinator/GreenEnergyHub.Aggregation.Infrastructure/CoordinatorSettings.cs
+++ b/source/coordinator/GreenEnergyHub.Aggregation.Infrastructure/CoordinatorSettings.cs
@@ -38,6 +38,8 @@ namespace GreenEnergyHub.Aggregation.Infrastructure
 
         public string ConnectionStringDatabricks { get; set;  }
 
+        public string HostKey { get; set; }
+
         public string TokenDatabricks { get; set; }
 
         public Uri ResultUrl { get; set; }


### PR DESCRIPTION
To tie the internal endpoints tighter to the coordinator the access has been locked to use system function keys.
This means that the databricks job is able to talk to the coordinator with the key, but other system/people will not be able to without that key. 
