### PR TITLE
Feature/flake8 linting remote container fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.linting.flake8Enabled": true
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -22,7 +23,6 @@
 		"ms-python.python",
 		"littlefoxteam.vscode-python-test-adapter",
 		"hbenl.vscode-test-explorer",
-		"kevinglasson.cornflakes-linter",
 		"eamodio.gitlens",
 		"ms-python.vscode-pylance",
 		"HashiCorp.terraform"

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -96,7 +96,6 @@ The Green Energy Hub repository relies on open source libraries and tools. We re
 | `Azure CLI` | | <https://aka.ms/InstallAzureCLIDeb> | MIT |
 | `bash-completion` | Current | <https://github.com/scop/bash-completion> | GPL-2.0 |
 | `ca-certificates-java` | Current | <https://packages.debian.org/jessie/ca-certificates-java> | <https://www.debian.org/license> |
-| `cornflakes-linter` | Current | <https://marketplace.visualstudio.com/items?itemName=kevinglasson.cornflakes-linter> | MIT |
 | `Databricks-cli` | Current | <https://github.com/databricks/databricks-cli> | Apache-2.0 |
 | `Flake8` | Current | <https://github.com/PyCQA/flake8> | MIT |
 | `GitLens - Git supercharged` | Current | <https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens> | MIT |

--- a/source/databricks/setup.cfg
+++ b/source/databricks/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-ignore = E501,F401,E402,W503,E122,E123,E126,F811
-max-line-length = 200

--- a/source/databricks/tox.ini
+++ b/source/databricks/tox.ini
@@ -1,0 +1,4 @@
+# Configure flake8 to fit development environment
+[flake8]
+ignore = F401,E402,W503,E122,E123,E126,F811
+max-line-length = 200


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

This PR helps out our struggle with flake8 not being able to apply settings set in the `setup.cfg` file eg. ignore E501, setting max line length.

- Enable `flake8` in docker container
- Remove rule E501 (line too long) from ignore list
- Set `max-line-length` to 200 (E501 will throw a warning if we reach 200 characters)
- Remove `cornflakes linter` to avoid duplicate warning errors and stick to `flake8` as our linter

It's important to remove all flake8 related settings in `settings.json` (both local and workspace) to avoid any overwriting of the rules applied in [`tox.ini`](https://github.com/Energinet-DataHub/geh-aggregations/blob/feature/flake8-linting-remote-container-fixes/source/databricks/tox.ini).

Rebuild docker container to apply these changes and our linting will work as expected in our local dev environment.
