### PR TITLE
extend list of vs code extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,9 @@
 		"hbenl.vscode-test-explorer",
 		"eamodio.gitlens",
 		"ms-python.vscode-pylance",
-		"HashiCorp.terraform"
+		"HashiCorp.terraform",
+		"christian-kohler.path-intellisense",
+		"Gruntfuggly.todo-tree"
 	],
 
 	"containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,8 @@
 		"ms-python.vscode-pylance",
 		"HashiCorp.terraform",
 		"christian-kohler.path-intellisense",
-		"Gruntfuggly.todo-tree"
+		"Gruntfuggly.todo-tree",
+		"DavidAnson.vscode-markdownlint"
 	],
 
 	"containerEnv": {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Two very useful vs code extensions have been added to `.devcontainer.json` and are installed when building the docker image:
1)  [TODO Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree)
2) [Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense) 
3) [Markdown lint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)