### PR TITLE
Feature/fix magic strings in schemas

### DIFF
--- a/source/databricks/geh_stream/codelists/__init__.py
+++ b/source/databricks/geh_stream/codelists/__init__.py
@@ -16,5 +16,5 @@ from .quality import Quality
 from .settlement_method import SettlementMethod
 from .resolution_duration import ResolutionDuration
 from .connectionState import ConnectionState
-from .columns import Colname
+from .colname import Colname
 from .date_formats import DateFormat

--- a/source/databricks/geh_stream/codelists/colname.py
+++ b/source/databricks/geh_stream/codelists/colname.py
@@ -49,3 +49,6 @@ class Colname():
     time_window_end = "time_window.end"
     time_window_start = "time_window.start"
     to_date = "to_date"
+    net_settlement_group = "net_settlement_group"
+    parent_metering_point_id = "parent_metering_point_id"
+    unit = "unit"

--- a/source/databricks/geh_stream/schemas/charges_schema.py
+++ b/source/databricks/geh_stream/schemas/charges_schema.py
@@ -12,30 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from geh_stream.codelists.columns import Colname
 from pyspark.sql.types import DecimalType, StructType, StructField, StringType, TimestampType
 
 charges_schema = StructType([
-      StructField("charge_id", StringType(), False),
-      StructField("charge_type", StringType(), False),
-      StructField("charge_owner", StringType(), False),
-      StructField("resolution", StringType(), False),
-      StructField("charge_tax", StringType(), False),
-      StructField("currency", StringType(), False),
-      StructField("from_date", TimestampType(), False),
-      StructField("to_date", TimestampType(), False),
+      StructField(Colname.charge_id, StringType(), False),
+      StructField(Colname.charge_type, StringType(), False),
+      StructField(Colname.charge_owner, StringType(), False),
+      StructField(Colname.resolution, StringType(), False),
+      StructField(Colname.charge_tax, StringType(), False),
+      StructField(Colname.currency, StringType(), False),
+      StructField(Colname.from_date, TimestampType(), False),
+      StructField(Colname.to_date, TimestampType(), False),
 ])
 
 
 charge_links_schema = StructType([
-      StructField("charge_id", StringType(), False),
-      StructField("metering_point_id", StringType(), False),
-      StructField("from_date", TimestampType(), False),
-      StructField("to_date", TimestampType(), False),
+      StructField(Colname.charge_id, StringType(), False),
+      StructField(Colname.metering_point_id, StringType(), False),
+      StructField(Colname.from_date, TimestampType(), False),
+      StructField(Colname.to_date, TimestampType(), False),
 ])
 
 
 charge_prices_schema = StructType([
-      StructField("charge_id", StringType(), False),
-      StructField("charge_price", DecimalType(18, 6), False),
-      StructField("time", TimestampType(), False),
+      StructField(Colname.charge_id, StringType(), False),
+      StructField(Colname.charge_price, DecimalType(18, 6), False),
+      StructField(Colname.time, TimestampType(), False),
 ])

--- a/source/databricks/geh_stream/schemas/charges_schema.py
+++ b/source/databricks/geh_stream/schemas/charges_schema.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from geh_stream.codelists.columns import Colname
+from geh_stream.codelists import Colname
 from pyspark.sql.types import DecimalType, StructType, StructField, StringType, TimestampType
 
 charges_schema = StructType([

--- a/source/databricks/geh_stream/schemas/es_brp_relations_schema.py
+++ b/source/databricks/geh_stream/schemas/es_brp_relations_schema.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from geh_stream.codelists.columns import Colname
+from geh_stream.codelists import Colname
 from pyspark.sql.types import StructType, StructField, StringType, TimestampType
 
 es_brp_relations_schema = StructType([

--- a/source/databricks/geh_stream/schemas/es_brp_relations_schema.py
+++ b/source/databricks/geh_stream/schemas/es_brp_relations_schema.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from geh_stream.codelists.columns import Colname
 from pyspark.sql.types import StructType, StructField, StringType, TimestampType
 
 es_brp_relations_schema = StructType([
-      StructField("energy_supplier_id", StringType(), False),
-      StructField("balance_responsible_id", StringType(), False),
-      StructField("grid_area", StringType(), False),
-      StructField("metering_point_type", StringType(), False),
-      StructField("from_date", TimestampType(), False),
-      StructField("to_date", TimestampType(), False)
+      StructField(Colname.energy_supplier_id, StringType(), False),
+      StructField(Colname.balance_responsible_id, StringType(), False),
+      StructField(Colname.grid_area, StringType(), False),
+      StructField(Colname.metering_point_type, StringType(), False),
+      StructField(Colname.from_date, TimestampType(), False),
+      StructField(Colname.to_date, TimestampType(), False)
 ])

--- a/source/databricks/geh_stream/schemas/grid_loss_sys_corr_schema.py
+++ b/source/databricks/geh_stream/schemas/grid_loss_sys_corr_schema.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from geh_stream.codelists.columns import Colname
 from pyspark.sql.types import BooleanType, StructType, StructField, StringType, TimestampType
 
 grid_loss_sys_corr_schema = StructType([
-      StructField("metering_point_id", StringType(), False),
-      StructField("grid_area", StringType(), False),
-      StructField("energy_supplier_id", StringType(), False),
-      StructField("is_grid_loss", BooleanType(), False),
-      StructField("is_system_correction", BooleanType(), False),
-      StructField("from_date", TimestampType(), False),
-      StructField("to_date", TimestampType(), False)
+      StructField(Colname.metering_point_id, StringType(), False),
+      StructField(Colname.grid_area, StringType(), False),
+      StructField(Colname.energy_supplier_id, StringType(), False),
+      StructField(Colname.is_grid_loss, BooleanType(), False),
+      StructField(Colname.is_system_correction, BooleanType(), False),
+      StructField(Colname.from_date, TimestampType(), False),
+      StructField(Colname.to_date, TimestampType(), False)
 ])

--- a/source/databricks/geh_stream/schemas/grid_loss_sys_corr_schema.py
+++ b/source/databricks/geh_stream/schemas/grid_loss_sys_corr_schema.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from geh_stream.codelists.columns import Colname
+from geh_stream.codelists import Colname
 from pyspark.sql.types import BooleanType, StructType, StructField, StringType, TimestampType
 
 grid_loss_sys_corr_schema = StructType([

--- a/source/databricks/geh_stream/schemas/market_roles_schema.py
+++ b/source/databricks/geh_stream/schemas/market_roles_schema.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from geh_stream.codelists.columns import Colname
+from geh_stream.codelists import Colname
 from pyspark.sql.types import StructType, StructField, StringType, TimestampType
 
 market_roles_schema = StructType([

--- a/source/databricks/geh_stream/schemas/market_roles_schema.py
+++ b/source/databricks/geh_stream/schemas/market_roles_schema.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from geh_stream.codelists.columns import Colname
 from pyspark.sql.types import StructType, StructField, StringType, TimestampType
 
 market_roles_schema = StructType([
-      StructField("energy_supplier_id", StringType(), False),
-      StructField("metering_point_id", StringType(), False),
-      StructField("from_date", TimestampType(), False),
-      StructField("to_date", TimestampType(), False)
+      StructField(Colname.energy_supplier_id, StringType(), False),
+      StructField(Colname.metering_point_id, StringType(), False),
+      StructField(Colname.from_date, TimestampType(), False),
+      StructField(Colname.to_date, TimestampType(), False)
 ])

--- a/source/databricks/geh_stream/schemas/metering_point_schema.py
+++ b/source/databricks/geh_stream/schemas/metering_point_schema.py
@@ -12,22 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from geh_stream.codelists.columns import Colname
 from pyspark.sql.types import StructType, StructField, StringType, TimestampType, IntegerType
 
 metering_point_schema = StructType([
-      StructField("metering_point_id", StringType(), False),
-      StructField("metering_point_type", StringType(), False),
-      StructField("settlement_method", StringType()),
-      StructField("grid_area", StringType(), False),
-      StructField("connection_state", StringType(), False),
-      StructField("resolution", StringType(), False),
-      StructField("in_grid_area", StringType()),
-      StructField("out_grid_area", StringType()),
-      StructField("metering_method", StringType(), False),
-      StructField("net_settlement_group", StringType()),
-      StructField("parent_metering_point_id", StringType()),
-      StructField("unit", StringType(), False),
-      StructField("product", StringType()),
-      StructField("from_date", TimestampType(), False),
-      StructField("to_date", TimestampType(), False)
+      StructField(Colname.metering_point_id, StringType(), False),
+      StructField(Colname.metering_point_type, StringType(), False),
+      StructField(Colname.settlement_method, StringType()),
+      StructField(Colname.grid_area, StringType(), False),
+      StructField(Colname.connection_state, StringType(), False),
+      StructField(Colname.resolution, StringType(), False),
+      StructField(Colname.in_grid_area, StringType()),
+      StructField(Colname.out_grid_area, StringType()),
+      StructField(Colname.metering_method, StringType(), False),
+      StructField(Colname.net_settlement_group, StringType()),
+      StructField(Colname.parent_metering_point_id, StringType()),
+      StructField(Colname.unit, StringType(), False),
+      StructField(Colname.product, StringType()),
+      StructField(Colname.from_date, TimestampType(), False),
+      StructField(Colname.to_date, TimestampType(), False)
 ])

--- a/source/databricks/geh_stream/schemas/metering_point_schema.py
+++ b/source/databricks/geh_stream/schemas/metering_point_schema.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from geh_stream.codelists.columns import Colname
+from geh_stream.codelists import Colname
 from pyspark.sql.types import StructType, StructField, StringType, TimestampType, IntegerType
 
 metering_point_schema = StructType([

--- a/source/databricks/geh_stream/schemas/time_series_schema.py
+++ b/source/databricks/geh_stream/schemas/time_series_schema.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from geh_stream.codelists.columns import Colname
 from pyspark.sql.types import DecimalType, StructType, StructField, StringType, TimestampType
 
 time_series_schema = StructType([
-      StructField("metering_point_id", StringType(), False),
-      StructField("quantity", DecimalType(18, 3), False),
-      StructField("quality", StringType(), False),
-      StructField("time", TimestampType(), False),
+      StructField(Colname.metering_point_id, StringType(), False),
+      StructField(Colname.quantity, DecimalType(18, 3), False),
+      StructField(Colname.quality, StringType(), False),
+      StructField(Colname.time, TimestampType(), False),
 ])

--- a/source/databricks/geh_stream/schemas/time_series_schema.py
+++ b/source/databricks/geh_stream/schemas/time_series_schema.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from geh_stream.codelists.columns import Colname
+from geh_stream.codelists import Colname
 from pyspark.sql.types import DecimalType, StructType, StructField, StringType, TimestampType
 
 time_series_schema = StructType([


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description
Replace magic strings left in the schemas folder.

- Rename `columns.py` to `colname.py` to match with class name
- Replace magic strings and use `Colname`
- Add missing attributes to `colname.py`
