### PR TITLE
Feature/212 add property to charges

### DIFF
--- a/source/databricks/geh_stream/codelists/colname.py
+++ b/source/databricks/geh_stream/codelists/colname.py
@@ -18,6 +18,7 @@ class Colname():
     added_system_correction = "added_system_correction"
     aggregated_quality = "aggregated_quality"
     balance_responsible_id = "balance_responsible_id"
+    charge_id = "charge_id"
     charge_key = "charge_key"
     charge_owner = "charge_owner"
     charge_price = "charge_price"

--- a/source/databricks/geh_stream/schemas/charges_schema.py
+++ b/source/databricks/geh_stream/schemas/charges_schema.py
@@ -17,6 +17,7 @@ from pyspark.sql.types import DecimalType, StructType, StructField, StringType, 
 
 charges_schema = StructType([
       StructField(Colname.charge_key, StringType(), False),
+      StructField(Colname.charge_id, StringType(), False),
       StructField(Colname.charge_type, StringType(), False),
       StructField(Colname.charge_owner, StringType(), False),
       StructField(Colname.resolution, StringType(), False),

--- a/source/test-data-generation/GreenEnergyHub.Aggregation.TestData.Application/Parsers/TestDataParserBase.cs
+++ b/source/test-data-generation/GreenEnergyHub.Aggregation.TestData.Application/Parsers/TestDataParserBase.cs
@@ -45,7 +45,7 @@ namespace GreenEnergyHub.Aggregation.TestData.Application.Parsers
             using var tr = new StreamReader(stream);
             using var csv = new CsvReader(tr, new CsvConfiguration(CultureInfo.InvariantCulture)
             {
-                Delimiter = ";",
+                Delimiter = ",",
                 HasHeaderRecord = true,
                 IgnoreBlankLines = true,
                 ShouldSkipRecord = (r) => r.Record.All(string.IsNullOrEmpty),

--- a/source/test-data-generation/GreenEnergyHub.Aggregation.TestData.Infrastructure/Models/Charge.cs
+++ b/source/test-data-generation/GreenEnergyHub.Aggregation.TestData.Infrastructure/Models/Charge.cs
@@ -29,6 +29,9 @@ namespace GreenEnergyHub.Aggregation.TestData.Infrastructure.Models
         [JsonProperty(PropertyName = "charge_key")]
         public string ChargeKey { get; set; }
 
+        [JsonProperty(PropertyName = "charge_id")]
+        public string ChargeId { get; set; }
+
         [JsonProperty(PropertyName = "charge_type")]
         public string ChargeType { get; set; }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
- Re-add `charge_id` to `charges` test data and schema.
- Use `,` as csv delimiter.
- Excel sheet macro for generating charge prices updated to fix resolution value change in `Charges(Master)` so `ChargePrices(Auto)` has correct time.
- Excel sheet macro to generate csv files updated to use `.` as decimal separator and `,` as delimiter.
- Updated Excel Sheet can be found [here](https://teams.microsoft.com/l/file/406E5B79-3F88-4E80-B367-F3775DDA371C?tenantId=f7619355-6c67-4100-9a78-1847f30742e2&fileType=xlsm&objectUrl=https%3A%2F%2Fenerginet.sharepoint.com%2Fsites%2FJoules%2FDelte%20dokumenter%2FGeneral%2FTest%20data%2FExcel%20sheet%20(BRS-023%2BBRS-027)v21.xlsb.xlsm&baseUrl=https%3A%2F%2Fenerginet.sharepoint.com%2Fsites%2FJoules&serviceName=teams&threadId=19:9be4db802bd24ed99af96f025a839eb2@thread.tacv2&groupId=e986ad70-5310-4581-bc33-eed0503bdfde)

**Decimal value in `charge_prices` now reflects value in excel data:**
![chrome_lmbzakgcvE](https://user-images.githubusercontent.com/3176163/129853650-ac1a590c-74a5-414b-8940-f5d4ef7f1149.png)

**`charge_id` re-added to `charges`:**
![chrome_W0G9xINXd6](https://user-images.githubusercontent.com/3176163/129853706-4925a0aa-eb20-478f-ab68-d0afafa218d5.png)


## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #212 
