### PR TITLE
add how=inner explicit to all inner joins

### DIFF
--- a/source/databricks/geh_stream/aggregation_utils/aggregators/aggregate_quality.py
+++ b/source/databricks/geh_stream/aggregation_utils/aggregators/aggregate_quality.py
@@ -54,7 +54,7 @@ def aggregate_quality(time_series_df: DataFrame):
               & (dayofmonth(time_series_df[Colname.time]) == dayofmonth(agg_df[Colname.time]))
               & (hour(time_series_df[Colname.time]) == hour(agg_df[Colname.time]))
               & (time_series_df[Colname.metering_point_type] == agg_df[Colname.metering_point_type])
-              & (time_series_df[Colname.grid_area] == agg_df[Colname.grid_area])) \
+              & (time_series_df[Colname.grid_area] == agg_df[Colname.grid_area]), "inner") \
         .select(time_series_df["*"], agg_df[Colname.aggregated_quality])
     return joined_df
 

--- a/source/databricks/geh_stream/aggregation_utils/aggregators/aggregation_initializer.py
+++ b/source/databricks/geh_stream/aggregation_utils/aggregators/aggregation_initializer.py
@@ -87,7 +87,7 @@ def get_time_series_dataframe(time_series_df, metering_point_df, market_roles_df
         ]
 
     time_series_with_metering_point = time_series_df \
-        .join(metering_point_df, metering_point_join_conditions) \
+        .join(metering_point_df, metering_point_join_conditions, "inner") \
         .drop(metering_point_df.metering_point_id) \
         .drop(metering_point_df.from_date) \
         .drop(metering_point_df.to_date)
@@ -128,11 +128,11 @@ def get_time_series_dataframe(time_series_df, metering_point_df, market_roles_df
     #     .join(charge_prices_df, ["charge_key"], "left") \
     #     .filter((col("time") >= col("from_date"))) \
     #     .filter((col("time") <= col("to_date"))) \
-    #     .join(charge_links_df, ["charge_key", "from_date", "to_date"])
+    #     .join(charge_links_df, ["charge_key", "from_date", "to_date"], "inner")
     # charges_with_prices_and_links.show()
 
     # time_series_with_metering_point_and_charges = time_series_with_metering_point \
-    #     .join(charges_with_prices_and_links, ["metering_point_id", "from_date", "to_date"])
+    #     .join(charges_with_prices_and_links, ["metering_point_id", "from_date", "to_date"], "inner")
 
     return time_series_with_metering_point_and_market_roles_and_brp
 

--- a/source/databricks/geh_stream/aggregation_utils/aggregators/aggregators.py
+++ b/source/databricks/geh_stream/aggregation_utils/aggregators/aggregators.py
@@ -46,7 +46,7 @@ def aggregate_net_exchange_per_neighbour_ga(df: DataFrame):
         .withColumnRenamed(Colname.out_grid_area, exchange_out_out_grid_area)
 
     exchange = exchange_in.join(
-        exchange_out, [Colname.time_window]) \
+        exchange_out, [Colname.time_window], "inner") \
         .filter(exchange_in.ExIn_InMeteringGridArea_Domain_mRID == exchange_out.ExOut_OutMeteringGridArea_Domain_mRID) \
         .filter(exchange_in.ExIn_OutMeteringGridArea_Domain_mRID == exchange_out.ExOut_InMeteringGridArea_Domain_mRID) \
         .select(exchange_in["*"], exchange_out[out_sum]) \

--- a/source/databricks/geh_stream/aggregation_utils/aggregators/combine_master_data.py
+++ b/source/databricks/geh_stream/aggregation_utils/aggregators/combine_master_data.py
@@ -45,5 +45,5 @@ def combine_master_data(timeseries_df: DataFrame, grid_loss_sys_cor_master_data_
             col(Colname.grid_area)
             == col(metering_grid_area_domain_mrid_drop)
         )
-        & (col(mp_check))
+        & (col(mp_check)), "inner"
     ).drop(metering_grid_area_domain_mrid_drop)

--- a/source/databricks/geh_stream/aggregation_utils/aggregators/grid_loss_calculator.py
+++ b/source/databricks/geh_stream/aggregation_utils/aggregators/grid_loss_calculator.py
@@ -83,7 +83,7 @@ def calculate_total_consumption(agg_net_exchange: DataFrame, agg_production: Dat
         .withColumnRenamed(f"sum({Colname.sum_quantity})", exchange_sum_quantity) \
         .withColumnRenamed(Colname.aggregated_quality, aggregated_net_exchange_quality)
 
-    result = result_production.join(result_net_exchange, [Colname.grid_area, Colname.time_window]) \
+    result = result_production.join(result_net_exchange, [Colname.grid_area, Colname.time_window], "inner") \
         .withColumn(Colname.sum_quantity, col(production_sum_quantity) + col(exchange_sum_quantity))
 
     result = aggregate_total_consumption_quality(result).orderBy(Colname.grid_area, Colname.time_window)

--- a/source/databricks/geh_stream/wholesale_utils/calculators/subscription_calculators.py
+++ b/source/databricks/geh_stream/wholesale_utils/calculators/subscription_calculators.py
@@ -33,7 +33,7 @@ def calculate_daily_subscription_price(spark: SparkSession, charges: DataFrame, 
 
     # Join charges and charge_prices
     charges_with_prices = charge_prices \
-        .join(subscription_charges, [Colname.charge_key]) \
+        .join(subscription_charges, [Colname.charge_key], "inner") \
         .selectExpr(
             Colname.charge_key,
             Colname.charge_id,
@@ -82,7 +82,7 @@ def calculate_daily_subscription_price(spark: SparkSession, charges: DataFrame, 
         )
 
     # Join the two exploded dataframes on charge_key and the new column date
-    charges_with_price_per_day_and_links = charges_with_price_per_day_exploded.join(charge_links_exploded, [Colname.charge_key, Colname.date]) \
+    charges_with_price_per_day_and_links = charges_with_price_per_day_exploded.join(charge_links_exploded, [Colname.charge_key, Colname.date], "inner") \
         .selectExpr(
             Colname.charge_key,
             Colname.metering_point_id,
@@ -101,7 +101,7 @@ def calculate_daily_subscription_price(spark: SparkSession, charges: DataFrame, 
         charges_with_price_per_day_and_links[Colname.date] < metering_points[Colname.to_date]
     ]
 
-    charges_per_day_with_metering_point = charges_with_price_per_day_and_links.join(metering_points, charges_per_day_with_metering_point_join_condition) \
+    charges_per_day_with_metering_point = charges_with_price_per_day_and_links.join(metering_points, charges_per_day_with_metering_point_join_condition, "inner") \
         .select(
             Colname.charge_key,
             metering_points[Colname.metering_point_id],
@@ -124,7 +124,7 @@ def calculate_daily_subscription_price(spark: SparkSession, charges: DataFrame, 
         charges_per_day_with_metering_point[Colname.date] < market_roles[Colname.to_date]
     ]
 
-    charges_per_day_with_metering_point_and_energy_supplier = charges_per_day_with_metering_point.join(market_roles, charges_per_day_with_metering_point_and_energy_supplier_join_condition) \
+    charges_per_day_with_metering_point_and_energy_supplier = charges_per_day_with_metering_point.join(market_roles, charges_per_day_with_metering_point_and_energy_supplier_join_condition, "inner") \
         .select(
             Colname.charge_key,
             Colname.charge_id,
@@ -161,7 +161,7 @@ def calculate_daily_subscription_price(spark: SparkSession, charges: DataFrame, 
         )
 
     df = charges_per_day_flex_settled_consumption \
-        .select("*").distinct().join(grouped_charges_per_day, [Colname.charge_owner, Colname.grid_area, Colname.energy_supplier_id, Colname.date]) \
+        .select("*").distinct().join(grouped_charges_per_day, [Colname.charge_owner, Colname.grid_area, Colname.energy_supplier_id, Colname.date], "inner") \
         .select(
             Colname.charge_key,
             Colname.charge_id,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
When joining dataframes the `join` method the `how` parameter is set jo `inner` as default. We would like to be explicit and set `how` manually in each join.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #276 
