### PR TITLE
change branch to main

### DIFF
--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -15,7 +15,7 @@ name: Code coverage
 on:
    push:
      branches:
-       - bug/262-fix-result-name-in-sql
+       - main
    pull_request:
      branches:
        - main


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
Testing of code cov github action got merged into main. 
This fixes the `on push` to point at `main`
