### PR TITLE
enable dependabot on coordinator projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,49 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/source/hello-world"
+    directory: "/source/coordinator/GreenEnergyHub.Aggregation.Application"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "nuget"
+    directory: "/source/coordinator/GreenEnergyHub.Aggregation.Coordinator"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "nuget"
+    directory: "/source/coordinator/GreenEnergyHub.Aggregation.Core"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "nuget"
+    directory: "/source/coordinator/GreenEnergyHub.Aggregation.DatabaseMigration"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "nuget"
+    directory: "/source/coordinator/GreenEnergyHub.Aggregation.Domain"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "nuget"
+    directory: "/source/coordinator/GreenEnergyHub.Aggregation.Infrastructure"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "nuget"
+    directory: "/source/coordinator/GreenEnergyHub.Aggregation.Tests"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "nuget"
+    directory: "/source/coordinator/GreenEnergyHub.Aggregation.Tests"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
Enable `dependabot` on all coordinator projects.
