### PR TITLE
use specific version of scipy notebook

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,5 @@
 #FKT 24 Feb 2021: Fixed to specific version because of build errors
-# FROM jupyter/scipy-notebook:016833b15ceb 
-FROM jupyter/base-notebook
+FROM jupyter/scipy-notebook:016833b15ceb 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root


### PR DESCRIPTION
If we use base-notebook a newer version of python is installed and we get breaking changes in the PyPi packages installed with hardcoded versions.

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
Use specific version of scipy notebook to make sure the installed python version is `3.8` to allow us to use interpreter `3.8.5`. We need to stick to that version of the notebook until we have a upgrade strategy. All our PyPi packages are installed with a hardcoded version and it can lead to breaking changes locally if the versions are not compatible.