### PR TITLE
Restore SonarCloud configuration

### DIFF
--- a/.github/workflows/sonarcloud-dotnet.yml
+++ b/.github/workflows/sonarcloud-dotnet.yml
@@ -1,0 +1,56 @@
+name: SonarCloudDotnet
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - source/coordinator/**
+      - source/messaging/**
+      - .github/workflows/sonarcloud-dotnet.yml
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+env:
+  SOLUTION_PATH: 'source\coordinator\GreenEnergyHub.Aggregation.sln'
+  DOTNET_VERSION: '3.1'
+jobs:
+  build:
+    name: Build
+    runs-on: windows-latest
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache SonarCloud scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v1
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+      - name: Install SonarCloud scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          New-Item -Path .\.sonar\scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: powershell
+        run: |
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"geh-aggregations-dotnet" /o:"energinet-datahub" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          dotnet build ${{ env.SOLUTION_PATH }} --configuration Release
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+              

--- a/.github/workflows/sonarcloud-dotnet.yml
+++ b/.github/workflows/sonarcloud-dotnet.yml
@@ -12,7 +12,10 @@ on:
     types: [opened, synchronize, reopened]
 env:
   SOLUTION_PATH: 'source\coordinator\GreenEnergyHub.Aggregation.sln'
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.x'
+  SONAR_PROJECTKEY: 'geh-aggregations-dotnet'
+  SOURCE_PATH_ON_BUILDMACHINE: 'D:\a\geh-aggregations\geh-aggregations\source' # We have to be speficic with this path to get around a .NET 5.0 issue in SonarCLoud
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
     name: Build
@@ -22,6 +25,17 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'      
+      
+      - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
@@ -50,7 +64,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"geh-aggregations-dotnet" /o:"energinet-datahub" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"${{ env.SONAR_PROJECTKEY }}" /o:"energinet-datahub" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.projectBaseDir="${{ env.SOURCE_PATH_ON_BUILDMACHINE }}" /d:sonar.host.url="https://sonarcloud.io"
           dotnet build ${{ env.SOLUTION_PATH }} --configuration Release
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
               


### PR DESCRIPTION
## Description

This PR will restore SonarCloud workflow in the build pipeline. The reason for this is that we need to be ready for a security audit in near future.

At a later stage this will be moved to be a part of the generic build flow in geh-core.