### PR TITLE
Remove bash-completion

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ ENV APACHE_SPARK_VERSION="${spark_version}" \
 RUN apt-get -y update && \
     apt-get install --no-install-recommends -y \
     "openjdk-${openjdk_version}-jre-headless" \
-    "openssh-client" "git" "bash-completion" \
+    "openssh-client" "git" \
     "aspell" "aspell-en" \
     "flake8" \
     "ca-certificates-java" && \

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -93,7 +93,6 @@ The Green Energy Hub repository relies on open source libraries and tools. We re
 | `Apache Spark` | 3.0.2 | <https://spark.apache.org/releases/spark-release-3-0-2.html> | Apache-2.0 |
 | `Aspell` | Current | <http://aspell.net/> | |
 | `Azure CLI` | | <https://aka.ms/InstallAzureCLIDeb> | MIT |
-| `bash-completion` | Current | <https://github.com/scop/bash-completion> | GPL-2.0 |
 | `ca-certificates-java` | Current | <https://packages.debian.org/jessie/ca-certificates-java> | <https://www.debian.org/license> |
 | `Databricks-cli` | Current | <https://github.com/databricks/databricks-cli> | Apache-2.0 |
 | `Flake8` | Current | <https://github.com/PyCQA/flake8> | MIT |


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Remove bash-completion because it has GPL-2 license which is not compatible with Apache License v2.0
OpenJDK is also using GPL-2, but it is using a different kind that does not conflict "GPL-2.0-only with linking exception"

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #631 
