### PR TITLE
Set pytest to only look in tests folder

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,3 +2,5 @@
 [flake8]
 ignore = F401,E402,W503,E122,E123,E126,F811
 max-line-length = 200
+[pytest]
+testpaths = source/databricks/tests


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description
Make pytest faster my only looking at files that are in the tests folder
Before:
![image](https://user-images.githubusercontent.com/39729843/161732157-8260b2a3-bf09-4481-be99-22b39c59b8cd.png)
After:
![image](https://user-images.githubusercontent.com/39729843/161732211-5299ae82-a941-44ab-a3a5-66bbf0315f5e.png)


## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
