### PR TITLE
Add jedi as default language server in container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,9 @@
 		"args": {
 		}
 	},
-    "extensions": [
-        "ms-dotnettools.dotnet-interactive-vscode",
-        "ms-python.python",
+	"extensions": [
+		"ms-dotnettools.dotnet-interactive-vscode",
+		"ms-python.python",
 		"littlefoxteam.vscode-python-test-adapter",
 		"hbenl.vscode-test-explorer",
 		"eamodio.gitlens",
@@ -16,15 +16,15 @@
 		"christian-kohler.path-intellisense",
 		"Gruntfuggly.todo-tree",
 		"DavidAnson.vscode-markdownlint",
-        "kevinglasson.cornflakes-linter",
-        "KevinRose.vsc-python-indent",
-        "TabNine.tabnine-vscode"
-    ],
+		"kevinglasson.cornflakes-linter",
+		"KevinRose.vsc-python-indent",
+		"TabNine.tabnine-vscode"
+	],
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
-        "python.linting.flake8Enabled": true,
+		"python.linting.flake8Enabled": true,
 		"python.languageServer": "Jedi"
 	},
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
-        "python.linting.flake8Enabled": true
+        "python.linting.flake8Enabled": true,
+		"python.languageServer": "Jedi"
 	},
 
 	"containerEnv": {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Add jedi as default language server in container to get better developer experience out of the box

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #616 
