### PR TITLE
bugfix: Multiple threads accessing DbContext

### DIFF
--- a/source/IntegrationEventListener/source/Energinet.DataHub.Aggregations.IntegrationEventListener/Program.cs
+++ b/source/IntegrationEventListener/source/Energinet.DataHub.Aggregations.IntegrationEventListener/Program.cs
@@ -75,13 +75,11 @@ namespace Energinet.DataHub.Aggregations
                 services.AddScoped<FunctionInvocationLoggingMiddleware>();
                 services.AddSingleton<IJsonSerializer, JsonSerializer>();
                 services.AddSingleton<EventDataHelper>();
-
+                services.AddScoped<IMasterDataDbContext, MasterDataDbContext>();
                 services.AddDbContext<MasterDataDbContext>(
                     options => options.UseSqlServer(
                         context.Configuration[EnvironmentSettingNames.MasterDataDbConString],
                         o => o.UseNodaTime()));
-
-                services.AddScoped<IMasterDataDbContext, MasterDataDbContext>();
                 services.AddScoped<IMasterDataRepository<MeteringPoint>, MeteringPointRepository>();
 
                 SetupMutators(services);

--- a/source/IntegrationEventListener/source/Energinet.DataHub.Aggregations.IntegrationEventListener/Program.cs
+++ b/source/IntegrationEventListener/source/Energinet.DataHub.Aggregations.IntegrationEventListener/Program.cs
@@ -98,13 +98,13 @@ namespace Energinet.DataHub.Aggregations
         private static void SetupMutators(IServiceCollection services)
         {
             services
-                .AddSingleton<IEventToMasterDataTransformer<MeteringPointCreatedMutator>,
+                .AddScoped<IEventToMasterDataTransformer<MeteringPointCreatedMutator>,
                     EventToMasterDataTransformer<MeteringPointCreatedMutator, MeteringPoint>>();
             services
-                .AddSingleton<IEventToMasterDataTransformer<MeteringPointConnectedMutator>,
+                .AddScoped<IEventToMasterDataTransformer<MeteringPointConnectedMutator>,
                     EventToMasterDataTransformer<MeteringPointConnectedMutator, MeteringPoint>>();
             services
-                .AddSingleton<IEventToMasterDataTransformer<SettlementMethodChangedMutator>,
+                .AddScoped<IEventToMasterDataTransformer<SettlementMethodChangedMutator>,
                     EventToMasterDataTransformer<SettlementMethodChangedMutator, MeteringPoint>>();
         }
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description
With the current registration, it is possible to access the DbContext from multiple threads - registering mutators as scoped will fix this.