### PR TITLE
Kerbou/use default dotnetsdk version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ on:
   pull_request:
     branches:
       - main
-  # Executed if manually triggered
-  workflow_dispatch: {}
-  
+
 jobs:
   ci_base:
     uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,12 @@ on:
 
 jobs:
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.3.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.8.0
 
   dotnet_solution_coordinator_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.8.0
     with:
       SOLUTION_FILE_PATH: 'source/coordinator/Energinet.DataHub.Aggregation.Coordinator.sln'
-      DOTNET_VERSION: '5.0.202'
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -35,10 +34,9 @@ jobs:
       AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
 
   dotnet_solution_integration_event_listener_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.8.0
     with:
       SOLUTION_FILE_PATH: 'source/IntegrationEventListener/Energinet.DataHub.Aggregations.sln'
-      DOTNET_VERSION: '5.0.202'
       USE_AZURE_FUNCTIONS_TOOLS: true
       USE_SQLLOCALDB_2019: true
     secrets:
@@ -50,20 +48,20 @@ jobs:
       AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
 
   databricks_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/python-ci-test-and-coverage.yml@7.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/python-ci-test-and-coverage.yml@7.8.0
     with:
       PATH_STATIC_CHECKS: './source'
       IGNORE_ERRORS_AND_WARNING_FLAKE8: 'E501,F401,E402,W503,E122,E123,E126,F811'
       TEST_REPORT_PATH: ./source/databricks/tests/coverage.json
 
   terraform_validate_main:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@7.8.0
     with:
       TERRAFORM_WORKING_DIR_PATH: "./build/primary/main"
       TERRAFORM_VERSION: "1.1.6"
 
   terraform_validate_aggregations_cluster:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@7.8.0
     with:
       TERRAFORM_WORKING_DIR_PATH: "./build/databricks_aggregations_cluster"
       TERRAFORM_VERSION: "1.1.6"
@@ -75,7 +73,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@7.8.0
     with:
       CSPROJ_FILE_PATH: "source/coordinator/Energinet.DataHub.Aggregation.Coordinator.CoordinatorFunction/Energinet.DataHub.Aggregation.Coordinator.CoordinatorFunction.csproj"
       DOTNET_VERSION: "5.0.202"
@@ -88,7 +86,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@7.8.0
     with:
       CSPROJ_FILE_PATH: "source/IntegrationEventListener/source/Energinet.DataHub.Aggregations.IntegrationEventListener/Energinet.DataHub.Aggregations.IntegrationEventListener.csproj"
       DOTNET_VERSION: "5.0.202"
@@ -101,7 +99,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/python-wheel-ci.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/python-wheel-ci.yml@7.8.0
     with:
       PYHTON_VERSION: "3.8.6"
       ARCHITECTURE: "x64"
@@ -116,7 +114,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@7.8.0
     with:
       CSPROJ_FILE_PATH: "source/coordinator/Energinet.DataHub.Aggregation.Coordinator.DatabaseMigration/Energinet.DataHub.Aggregation.Coordinator.DatabaseMigration.csproj"
       DOTNET_VERSION: "5.0"
@@ -129,7 +127,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@5.0.5
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@7.8.0
     with:
       CSPROJ_FILE_PATH: "source/IntegrationEventListener/Energinet.DataHub.Aggregations.DatabaseMigration/Energinet.DataHub.Aggregations.DatabaseMigration.csproj"
       DOTNET_VERSION: "5.0"
@@ -137,7 +135,7 @@ jobs:
 
   create_prerelease:
     needs: [coordinator_ci, integration_event_listener_ci, wheel_ci, masterdata_database_migration_ci, coordinator_database_migration_ci, databricks_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@6.1.2
+    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@7.8.0
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-aggregations
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ on:
 
 jobs:
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.3.0
 
   dotnet_solution_coordinator_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/coordinator/Energinet.DataHub.Aggregation.Coordinator.sln'
     secrets:
@@ -34,7 +34,7 @@ jobs:
       AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
 
   dotnet_solution_integration_event_listener_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/IntegrationEventListener/Energinet.DataHub.Aggregations.sln'
       USE_AZURE_FUNCTIONS_TOOLS: true
@@ -48,20 +48,20 @@ jobs:
       AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
 
   databricks_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/python-ci-test-and-coverage.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/python-ci-test-and-coverage.yml@7.0.0
     with:
       PATH_STATIC_CHECKS: './source'
       IGNORE_ERRORS_AND_WARNING_FLAKE8: 'E501,F401,E402,W503,E122,E123,E126,F811'
       TEST_REPORT_PATH: ./source/databricks/tests/coverage.json
 
   terraform_validate_main:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@6.1.2
     with:
       TERRAFORM_WORKING_DIR_PATH: "./build/primary/main"
       TERRAFORM_VERSION: "1.1.6"
 
   terraform_validate_aggregations_cluster:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@6.1.2
     with:
       TERRAFORM_WORKING_DIR_PATH: "./build/databricks_aggregations_cluster"
       TERRAFORM_VERSION: "1.1.6"
@@ -73,7 +73,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.2
     with:
       CSPROJ_FILE_PATH: "source/coordinator/Energinet.DataHub.Aggregation.Coordinator.CoordinatorFunction/Energinet.DataHub.Aggregation.Coordinator.CoordinatorFunction.csproj"
       DOTNET_VERSION: "5.0.202"
@@ -86,7 +86,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.2
     with:
       CSPROJ_FILE_PATH: "source/IntegrationEventListener/source/Energinet.DataHub.Aggregations.IntegrationEventListener/Energinet.DataHub.Aggregations.IntegrationEventListener.csproj"
       DOTNET_VERSION: "5.0.202"
@@ -99,7 +99,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/python-wheel-ci.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/python-wheel-ci.yml@6.1.2
     with:
       PYHTON_VERSION: "3.8.6"
       ARCHITECTURE: "x64"
@@ -114,7 +114,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.2
     with:
       CSPROJ_FILE_PATH: "source/coordinator/Energinet.DataHub.Aggregation.Coordinator.DatabaseMigration/Energinet.DataHub.Aggregation.Coordinator.DatabaseMigration.csproj"
       DOTNET_VERSION: "5.0"
@@ -127,7 +127,7 @@ jobs:
         terraform_validate_main,
         terraform_validate_aggregations_cluster,
       ]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@5.0.5
     with:
       CSPROJ_FILE_PATH: "source/IntegrationEventListener/Energinet.DataHub.Aggregations.DatabaseMigration/Energinet.DataHub.Aggregations.DatabaseMigration.csproj"
       DOTNET_VERSION: "5.0"
@@ -135,7 +135,7 @@ jobs:
 
   create_prerelease:
     needs: [coordinator_ci, integration_event_listener_ci, wheel_ci, masterdata_database_migration_ci, coordinator_database_migration_ci, databricks_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@7.8.0
+    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@6.1.2
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-aggregations
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ on:
   pull_request:
     branches:
       - main
-
+  # Executed if manually triggered
+  workflow_dispatch: {}
+  
 jobs:
   ci_base:
     uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.8.0


### PR DESCRIPTION
Speed up CI execution time by using default .NET Core SDK version pre-installed on hosted Github Runner